### PR TITLE
Add .tgz as a supported archive extension

### DIFF
--- a/installer_for_ext.go
+++ b/installer_for_ext.go
@@ -11,6 +11,7 @@ var installerForExt = map[string]InstallerType{
 	".bz2": InstallerTypeArchive,
 	".7z":  InstallerTypeArchive,
 	".tar": InstallerTypeArchive,
+	".tgz": InstallerTypeArchive,
 	".xz":  InstallerTypeArchive,
 	".rar": InstallerTypeArchive,
 


### PR DESCRIPTION
Game: https://alblune.itch.io/squeakross-home-squeak-home

Uses an archive with the file extensions .tgz which is not detected as an archive, breaking the install.

Log:
```
12 May 2026
19:29	butler	Queuing install for Squeakross: Home Squeak Home - https://alblune.itch.io/squeakross-home-squeak-home
19:29	butler	Generated fresh cave e590725b-9640-4647-8c85-bb59f504dc57
19:29	butler	Upload specified:
19:29	butler	  ☁ SqueakrossHSH_LINUX_1.72B.tgz :: 281.65 MiB :: #17420398
19:29	butler	    Executable :: Linux all
19:29	butler	Upload is not wharf-enabled
19:29	butler	→ Performing install for Squeakross: Home Squeak Home - https://alblune.itch.io/squeakross-home-squeak-home
19:29	butler	    to (/home/henry/.config/itch/apps/squeakross-home-squeak-home)
19:29	butler	    via (/home/henry/.config/itch/apps/downloads/closely-rational-impala)
19:29	butler	No receipt found.
19:29	butler	→ Starting fresh download session (3749ed3a-a328-4206-b655-473cf03fd97d)
19:29	butler	← No previous install info (no recorded upload or build)
19:29	butler	→ To be installed:
19:29	butler	  ☁ SqueakrossHSH_LINUX_1.72B.tgz :: 281.65 MiB :: #17420398
19:29	butler	    Executable :: Linux all
19:29	butler	(opening file took 469.448816ms)
19:29	butler	Determining source information...
19:29	butler	↝ For source (SqueakrossHSH_LINUX_1.72B.tgz)
19:29	butler	  No mapping for file extension (.tgz)
19:29	butler	Estimated disk usage (accuracy: guess)
19:29	butler	  ✓ 647.79 MiB needed free space
19:29	butler	  ✓ 366.14 MiB final disk usage
19:29	butler	Will use installer unknown
19:29	butler	No manager for installer unknown
```

Boar [also doesn't detect .tgz](https://github.com/itchio/boar/blob/418a6ee74f3545d64d3eab3916ed4153cb052c3a/probe.go#L241) but the 7zip fallback probably works fine.